### PR TITLE
AB#19335 Add a default PR template for the org

### DIFF
--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,0 +1,8 @@
+AB#
+
+## Description of changes
+
+## Breaking API Changes
+
+## Test logs or artifacts
+

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -4,5 +4,7 @@ AB#
 
 ## Breaking API Changes
 
-## Test logs or artifacts
+## Artifacts
+
+## Test logs
 


### PR DESCRIPTION
AB#19335 

Apparently this template will show for all our repos that don't have a custom one defined (i.e. in their .github folder)